### PR TITLE
Better Error Handling

### DIFF
--- a/server.js
+++ b/server.js
@@ -55,7 +55,7 @@ app.get("/markets", async function (req, res) {
             marketInfo.push(market);
         } catch (e) {
             console.error(e);
-            return res.status(400).json({ error: e.message, market: market_id });
+            marketInfo.push({ error: e.message, market: market_id });
         }
     }
     return res.status(200).json(marketInfo);


### PR DESCRIPTION
An error in any market causes an error in the full request right now. 

This version returns an error object in the slot for that market instead so that the remaining markets can be returned